### PR TITLE
feat: reuse history api for brainstorm games

### DIFF
--- a/scripts/game/game_storage.js
+++ b/scripts/game/game_storage.js
@@ -47,6 +47,16 @@ class GameStorage {
 
     // Flag to show that we need an update
     this.needUpdate = false;
+    if (this.isStormGame()) {
+      addEventListener('popstate', (event) => {
+        if (!event.state?.levelHash) {
+          return;
+        }
+  
+        const state = event.state.levelHash;
+        this.changeLevel(state.LevelId, state.LevelNumber, true);
+      });
+    }
   }
 
   isGameOver(){
@@ -554,9 +564,15 @@ class GameStorage {
     if (this.needUpdate) this.update({}, true);
   }
 
-  changeLevel(lid, ln){
+  changeLevel(lid, ln, skipPush = false){
     this.levelHash.LevelId = lid;
     this.levelHash.LevelNumber = ln;
+
+    if (this.isStormGame() && !skipPush) {
+      const url = new URL(location);
+      url.searchParams.set('level', ln);
+      history.pushState({ levelHash: { ...this.levelHash } }, '', url);
+    }
 
     this.update({}, true);
   }

--- a/scripts/game/game_storage.js
+++ b/scripts/game/game_storage.js
@@ -47,16 +47,14 @@ class GameStorage {
 
     // Flag to show that we need an update
     this.needUpdate = false;
-    if (this.isStormGame()) {
-      addEventListener('popstate', (event) => {
-        if (!event.state?.levelHash) {
-          return;
-        }
-  
-        const state = event.state.levelHash;
-        this.changeLevel(state.LevelId, state.LevelNumber, true);
-      });
-    }
+    addEventListener('popstate', (event) => {
+      if (!event.state?.levelHash || !this.isStormGame()) {
+        return;
+      }
+
+      const state = event.state.levelHash;
+      this.changeLevel(state.LevelId, state.LevelNumber, true);
+    });
   }
 
   isGameOver(){


### PR DESCRIPTION
Level navigation pushes state to history, so browser `refresh` and `back`/`forward` will be able to work correctly.