### PR TITLE
fix: allow jquery-ui tooltip to have linebreaks

### DIFF
--- a/style/play.css
+++ b/style/play.css
@@ -221,3 +221,7 @@ div#level-stat-dialog iframe {
 	background-color: #426f42;
   color: #00ff00;
 }
+
+.ui-tooltip {
+  white-space: pre-line;
+}


### PR DESCRIPTION
![image](https://github.com/L-Eugene/encx_extension/assets/19792546/9fbad2cc-5cc6-4262-a956-9b619768516a)
