### PR TITLE
fix: make sure scripts are working

### DIFF
--- a/background/service_worker.js
+++ b/background/service_worker.js
@@ -47,3 +47,41 @@ chrome.runtime.onMessage.addListener(
       }
     }
 );
+
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  if (request.scripts) {
+    try {
+      chrome.scripting.executeScript({
+        target: { tabId: sender.tab.id },
+        func: attachToDOM,
+        world: 'MAIN',
+        args: [request.scripts],
+      });
+    } catch {
+      // looks like we are in firefox
+      // try without `world`
+      chrome.scripting.executeScript({
+        target: { tabId: sender.tab.id },
+        func: attachToDOM,
+        args: [request.scripts],
+      });
+    }
+  }
+});
+
+/**
+ * Attaches script to DOM
+ * @param {{text?: string, src?: string, id: string}[]} value Script definition to attach to DOM
+ */
+function attachToDOM(value) {
+  value.forEach((script) => {
+    const tag = document.createElement('script');
+    if (script.text) {
+      tag.textContent = script.text;
+    } else if (script.src) {
+      tag.src = script.src;
+    }
+    const target = document.getElementById(script.id);
+    target.appendChild(tag);
+  });
+}

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -25,8 +25,12 @@
 
   "description": "__MSG_extensionDescription__",
 
-  "permissions": ["storage"],
-
+  "permissions": ["storage", "scripting"],
+  "host_permissions": [
+    "*://*.en.cx/gameengines/encounter/play/*",
+    "*://*.encounter.cx/gameengines/encounter/play/*",
+    "*://*.encounter.ru/gameengines/encounter/play/*"
+  ],
   "web_accessible_resources": [
     {
       "resources": [ "img/*", "style/images/*", "audio/*" ],

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -25,7 +25,12 @@
 
   "description": "__MSG_extensionDescription__",
 
-  "permissions": ["storage"],
+  "permissions": ["storage", "scripting"],
+  "host_permissions": [
+    "*://*.en.cx/gameengines/encounter/play/*",
+    "*://*.encounter.cx/gameengines/encounter/play/*",
+    "*://*.encounter.ru/gameengines/encounter/play/*"
+  ],
 
   "web_accessible_resources": [
     {

--- a/scripts/game/game_bonuses.js
+++ b/scripts/game/game_bonuses.js
@@ -142,7 +142,7 @@ class GameBonusManager extends GameManager {
           $("<div>")
             .addClass("bonus-hint")
             .attr("id", id)
-            .append(this.extractScripts(bonus.Help, id).replace(/\r\n/g, "<br>"))
+            .append(this.extractScripts(bonus.Help, id).replace(/\r?\n/g, "<br>"))
         )
         .append(
           (this.showBonusTask && (bonus.Task || '').length > 0)
@@ -151,7 +151,7 @@ class GameBonusManager extends GameManager {
                 .attr("id", `bonus-${bonus.BonusId}-task`)
                 .append(
                   encx_tpl.iframeSandbox(
-                    (bonus.Task || '').replace(/\r\n/g, "<br>")
+                    (bonus.Task || '').replace(/\r?\n/g, "<br>")
                   )
                 )
             : ''
@@ -167,7 +167,7 @@ class GameBonusManager extends GameManager {
         $("<div>")
           .addClass("bonus-task")
           .attr("id", id)
-          .append(this.extractScripts(bonus.Task || '', id).replace(/\r\n/g, "<br>"))
+          .append(this.extractScripts(bonus.Task || '', id).replace(/\r?\n/g, "<br>"))
       );
   }
 

--- a/scripts/game/game_bonuses.js
+++ b/scripts/game/game_bonuses.js
@@ -36,12 +36,14 @@ class GameBonusManager extends GameManager {
       function(bonus){
         if (this.storage.isBonusNew(bonus.BonusId)){
           $("div#bonuses").append(this._bonusTemplate(bonus));
+          this.attachScripts();
         } else if (
           this.storage.isBonusChanged(bonus.BonusId) ||
           $(`div#bonus-${bonus.BonusId}`).attr("update-mark")
         ){
           $(`div#bonus-${bonus.BonusId}`)
             .replaceWith(this._bonusTemplate(bonus));
+          this.attachScripts();
         }
 
         $(`#bonus-${bonus.BonusId}`).attr("delete-mark", false);
@@ -117,6 +119,7 @@ class GameBonusManager extends GameManager {
   }
 
   _bonusOpenTemplate(bonus){
+    const id = `bonus-${bonus.BonusId}-hint`;
     return [
       $("<div>")
         .addClass("spacer_answer"),
@@ -133,14 +136,13 @@ class GameBonusManager extends GameManager {
               .text(bonus.Answer.Answer)
           )
           .append(" ]"),
-
       $("<div>")
         .addClass("bonus")
         .append(
           $("<div>")
             .addClass("bonus-hint")
-            .attr("id", `bonus-${bonus.BonusId}-hint`)
-            .append((bonus.Help || '').replace(/\r\n/g, "<br>"))
+            .attr("id", id)
+            .append(this.extractScripts(bonus.Help, id).replace(/\r\n/g, "<br>"))
         )
         .append(
           (this.showBonusTask && (bonus.Task || '').length > 0)
@@ -158,13 +160,14 @@ class GameBonusManager extends GameManager {
   }
 
   _bonusClosedTemplate(bonus){
+    const id = `bonus-${bonus.BonusId}-task`;
     return $("<div>")
       .addClass("bonus")
       .append(
         $("<div>")
           .addClass("bonus-task")
-          .attr("id", `bonus-${bonus.BonusId}-task`)
-          .append((bonus.Task || '').replace(/\r\n/g, "<br>"))
+          .attr("id", id)
+          .append(this.extractScripts(bonus.Task || '', id).replace(/\r\n/g, "<br>"))
       );
   }
 

--- a/scripts/game/game_messages.js
+++ b/scripts/game/game_messages.js
@@ -38,8 +38,10 @@ class GameMessagesManager extends GameManager {
       function(message){
         if (this.storage.isMessageNew(message.MessageId)){
           $(".globalmess").append(this._messageTemplate(message));
+          this.attachScripts();
         } else if (this.storage.isMessageChanged(message.MessageId)){
           $(`#message-${message.MessageId}`).replaceWith(this._messageTemplate(message));
+          this.attachScripts();
         }
 
         $(`#message-${message.MessageId}`).attr("delete-mark", false);
@@ -56,9 +58,10 @@ class GameMessagesManager extends GameManager {
   }
 
   _messageTemplate(message){
+    const id = `message-${message.MessageId}`;
     return $("<div>")
       .addClass("message-block")
-      .attr("id", `message-${message.MessageId}`)
+      .attr("id", id)
       .attr("id-numeric", message.MessageId)
       .attr("delete-mark", false)
       .append(
@@ -70,7 +73,7 @@ class GameMessagesManager extends GameManager {
         $("<span>")
           .append(": ")
       )
-      .append(message.WrappedText)
+      .append(this.extractScripts(message.WrappedText, id))
       .append(
         $("<br>")
       );

--- a/scripts/game/game_task.js
+++ b/scripts/game/game_task.js
@@ -59,7 +59,7 @@ class GameTaskManager extends GameManager {
       .append(this._sectorsTemplate(storage.getLevel()))
       .append($("<div>").addClass("spacer"))
       .append(this._taskTemplate(storage.getLevel()));
-
+    this.attachScripts();
     this.task = storage.getTaskText();
     this.title = `${storage.getLevelNumber()}/${storage.getLevelCount()}`;
   }
@@ -127,6 +127,7 @@ class GameTaskManager extends GameManager {
     // Update task text
     if (storage.getTaskText() != this.task){
       $("#task").replaceWith(this._taskTemplate(storage.getLevel()));
+      this.attachScripts();
     }
   }
 
@@ -273,8 +274,9 @@ class GameTaskManager extends GameManager {
   }
 
   _taskTemplate(level){
+    const id = "task";
     var result = $("<div>")
-      .attr("id", "task")
+      .attr("id", id)
     if (level.Tasks.length == 0) return result;
 
     return result
@@ -283,7 +285,7 @@ class GameTaskManager extends GameManager {
       )
       .append(
         $("<p>")
-          .append(level.Tasks[0].TaskTextFormatted)
+          .append(this.extractScripts(level.Tasks[0].TaskTextFormatted, id))
       )
       .append(
         $("<div>")


### PR DESCRIPTION
Workaround due to migration to Manifest V3:

1. extract all scripts from bonuses/tasks/hints/messages
2. send all scripts to `service_worker` after appending the content
3. `service_worker` attaches scripts to DOM on required tab using `chrome.scripting` API.

[Firefox doesn't support](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld#browser_compatibility) `world: 'MAIN'` parameter, but somehow executes script inside the tab if parameter is not specified.

New permissions are added to manifest which can lead to [disabling extension for users](https://developer.chrome.com/docs/extensions/develop/concepts/permission-warnings).