### PR TITLE
fix: missing space after bonus name

### DIFF
--- a/scripts/game/game_bonuses.js
+++ b/scripts/game/game_bonuses.js
@@ -85,7 +85,7 @@ class GameBonusManager extends GameManager {
   _bonusInfoTemplate(bonus){
     return $("<span>")
       .addClass(bonus.Negative ? "color_pen" : "color_sec")
-      .append("(")
+      .append(" (")
       .append(chrome.i18n.getMessage("bonusCompleted"))
       .append(() => {
         if (bonus.AwardTime === 0) {


### PR DESCRIPTION
![image](https://github.com/L-Eugene/encx_extension/assets/19792546/80ec470f-c367-4995-92ba-65b21ae238ac)
