### PR TITLE
fix: set only one tooltip (html title) for bonus/penalty button

### DIFF
--- a/scripts/game/game_bonuses.js
+++ b/scripts/game/game_bonuses.js
@@ -66,8 +66,7 @@ class GameBonusManager extends GameManager {
           "bonusesClosedSummary",
           storage.getCompletedBonusesData()
         )
-      )
-      .tooltip();
+      );
 
     // Adjust iframe sizes
     $("div#bonuses iframe.bonus-task-frame").each(


### PR DESCRIPTION
![image](https://github.com/L-Eugene/encx_extension/assets/19792546/d16d42b9-de7d-46db-bf5e-42c465403116)
